### PR TITLE
Add Dockerfile for ROS2 Jazzy setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+build
+install
+log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ros:jazzy-ros-base
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install TurtleBot4 simulator and dependencies
+RUN apt-get update && \
+    apt-get install -y ros-jazzy-turtlebot4-simulator ros-jazzy-irobot-create-nodes && \
+    rm -rf /var/lib/apt/lists/*
+
+SHELL ["/bin/bash", "-c"]
+
+WORKDIR /ros2_ws
+COPY . /ros2_ws
+
+RUN rosdep update && \
+    rosdep install --from-paths src --ignore-src -r -y && \
+    colcon build --symlink-install
+
+RUN echo 'source /ros2_ws/install/setup.bash' >> ~/.bashrc
+
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -16,3 +16,14 @@ clone source
 cd src 
 git clone https://github.com/turtlebot/turtlebot4_simulator.git -b jazzy
 ```
+
+### Docker
+The repository provides a `Dockerfile` for running the simulator in a container. Build the image with:
+```bash
+docker build -t gmapping_py .
+```
+Run the container with:
+```bash
+docker run -it gmapping_py
+```
+The workspace is built during the image build and sourced automatically when the container starts.


### PR DESCRIPTION
## Summary
- provide Dockerfile and dockerignore for ROS2 Jazzy workspace
- document how to build and run the container

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684002a9e418832fb713c6dfe7e5d460